### PR TITLE
Loading local blueprint

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,3 +23,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           mode: 'append-to-description'
           plugin-path: .
+          blueprint-url: ./blueprint.json


### PR DESCRIPTION
This pull request makes a small update to the pull request preview workflow configuration by specifying the location of the blueprint file.

* Added the `blueprint-url` parameter to the `jobs` configuration in `.github/workflows/pr-preview.yml`, pointing to `./blueprint.json`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Ffellyph%2Fscrolldriven-block.git%22%2C%22ref%22%3A%22adding-blueprint-to-git-action%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->